### PR TITLE
Add LICENSE file and indication in DESCRIPTION

### DIFF
--- a/BrownMotion/DESCRIPTION
+++ b/BrownMotion/DESCRIPTION
@@ -2,7 +2,7 @@ Package: BrownMotion
 Version: 1.1
 Author: Peigen Zhou
 Maintainer: Peigen Zhou	<peigen@stat.wisc.edu>
-License: MIT
+License: MIT + file LICENSE
 Title: BrownMotion for homework
 Description: ....as you see
 URL: https://github.com/BaconZhou/BrownMotion

--- a/BrownMotion/LICENSE
+++ b/BrownMotion/LICENSE
@@ -1,0 +1,2 @@
+YEAR: 2015
+COPYRIGHT HOLDER: Peigen Zhou


### PR DESCRIPTION
Technically, when you use the MIT license, they want you to include a `LICENSE` file (containing copyright holder and year) and write `MIT + file LICENSE` in the `DESCRIPTION` file.
